### PR TITLE
Add Python build artifacts to .gitignore (*.egg-info)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ qzresearch/
 # Ignore Python compiled files
 __pycache__/
 *.py[cod]
+*.egg-info/
 
 # Ignore virtual environment
 venv/


### PR DESCRIPTION
This pull request adds Python build artifacts, specifically `*.egg-info` directories, to the .gitignore file.


